### PR TITLE
fix call-resume command

### DIFF
--- a/linphonelib/commands.py
+++ b/linphonelib/commands.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from linphonelib.exceptions import (
@@ -88,6 +88,17 @@ class CallStatusCommand(BaseCommand):
             return CallStatus.OFF
 
 
+class CallStatsCommand(BaseCommand):
+
+    command = 'call-stats'
+
+    def handle_status_ok(self, message):
+        return message
+
+    def handle_status_error(self, message):
+        raise LinphoneException(message['Reason'])
+
+
 class IsTalkingToCommand(BaseCommand):
 
     command = 'call-status'
@@ -152,7 +163,8 @@ class RegisterStatusCommand(BaseCommand):
 
 class ResumeCommand(BaseCommand):
 
-    command = 'call-resume'
+    def __init__(self, call_id):
+        self._call_id = call_id
 
     def handle_status_ok(self, message):
         pass
@@ -161,6 +173,12 @@ class ResumeCommand(BaseCommand):
         if message['Reason'] == 'No current call available.':
             raise NoActiveCallException()
         raise LinphoneException(message['Reason'])
+
+    @property
+    def command(self):
+        if self._call_id is None:
+            raise LinphoneException('Invalid call ID')
+        return 'call-resume {}'.format(self._call_id)
 
 
 class TransferCommand(BaseCommand):

--- a/linphonelib/session.py
+++ b/linphonelib/session.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -13,6 +13,7 @@ from linphonelib.commands import (
     AnswerCommand,
     CallCommand,
     CallStatusCommand,
+    CallStatsCommand,
     HangupCommand,
     HoldCommand,
     IsTalkingToCommand,
@@ -39,6 +40,7 @@ class Session:
         self._secret = secret
         self._hostname = hostname
         self._linphone_wrapper = _LinphoneWrapper(local_sip_port, local_rtp_port, logfile)
+        self._call_id = None
 
     def __str__(self):
         return 'Session %(_uname)s@%(_hostname)s' % self.__dict__
@@ -57,11 +59,16 @@ class Session:
 
     @_execute
     def hold(self):
+        self._call_id = self.call_stats()['Id']
         return HoldCommand()
 
     @_execute
     def call_status(self):
         return CallStatusCommand()
+
+    @_execute
+    def call_stats(self):
+        return CallStatsCommand()
 
     @_execute
     def register(self):
@@ -73,7 +80,9 @@ class Session:
 
     @_execute
     def resume(self):
-        return ResumeCommand()
+        id_to_resume = self._call_id
+        self._call_id = None
+        return ResumeCommand(id_to_resume)
 
     @_execute
     def is_talking_to(self, caller_id):


### PR DESCRIPTION
reason: when using call-resume, we need to pass the Id. So before doing
call-pause we save the Id into the session