### PR TITLE
test: use mock from unittest library

### DIFF
--- a/linphonelib/tests/test_client.py
+++ b/linphonelib/tests/test_client.py
@@ -1,15 +1,16 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import socket
 import unittest
+
+from unittest.mock import Mock, patch
 
 from hamcrest import (
     assert_that,
     instance_of,
     has_properties,
 )
-from mock import Mock, patch
 
 from ..client import LinphoneClient
 from ..exceptions import LinphoneConnectionError

--- a/linphonelib/tests/test_parser.py
+++ b/linphonelib/tests/test_parser.py
@@ -1,13 +1,14 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
+
+from unittest.mock import Mock
 
 from hamcrest import (
     assert_that,
     empty,
 )
-from mock import Mock
 
 from ..parser import parse_buffer
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest
 pytest


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package