### PR TITLE
Pull request for fix-container-stop

### DIFF
--- a/linphonelib/base_command.py
+++ b/linphonelib/base_command.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import abc
@@ -22,7 +22,7 @@ class BaseCommand(metaclass=abc.ABCMeta):
         elif message.status == 'Error':
             return self.handle_status_error(message.body)
 
-        raise NotImplementedError('Status: {}'.format(message.status))
+        raise NotImplementedError(f'Status: {message.status}')
 
     @abc.abstractmethod
     def handle_status_ok(self, message):

--- a/linphonelib/client.py
+++ b/linphonelib/client.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import collections
@@ -28,7 +28,7 @@ class LinphoneClient:
 
     def connect(self):
         if self._sock is None:
-            self._log_write('Connecting Linphone client to {}'.format(self._filename))
+            self._log_write(f'Connecting Linphone client to {self._filename}')
             self._connect_socket()
 
     def disconnect(self):
@@ -72,7 +72,7 @@ class LinphoneClient:
         return message
 
     def send_data(self, data):
-        self._log_write('Send data: {}'.format(data))
+        self._log_write(f'Send data: {data}')
         if isinstance(data, str):
             data = data.encode('utf-8')
         self._send_data_to_socket(data)
@@ -86,7 +86,7 @@ class LinphoneClient:
     def _recv_data_from_socket(self):
         try:
             data = self._sock.recv(self._BUFSIZE)
-            self._log_write('Received data: {}'.format(data))
+            self._log_write(f'Received data: {data}')
         except socket.error as e:
             raise LinphoneConnectionError(e)
         if not data:

--- a/linphonelib/commands.py
+++ b/linphonelib/commands.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from linphonelib.exceptions import (
@@ -37,7 +37,7 @@ class CallCommand(BaseCommand):
 
     @property
     def command(self):
-        return 'call sip:{}@{}'.format(self._exten, self._hostname)
+        return f'call sip:{self._exten}@{self._hostname}'
 
 
 class DTMFCommand(BaseCommand):
@@ -53,7 +53,7 @@ class DTMFCommand(BaseCommand):
 
     @property
     def command(self):
-        return 'dtmf {}'.format(self._digit)
+        return f'dtmf {self._digit}'
 
 
 class HangupCommand(BaseCommand):
@@ -126,7 +126,7 @@ class IsTalkingToCommand(BaseCommand):
             raise LinphoneException('Not in conversation')
 
         if self._caller_id not in message['From']:
-            raise LinphoneException('Do not talking to {}'.format(self._caller_id))
+            raise LinphoneException(f'Do not talking to {self._caller_id}')
 
         return True
 
@@ -146,7 +146,7 @@ class IsRingingShowingCommand(BaseCommand):
             raise LinphoneException('Not ringing')
 
         if self._caller_id not in message['From']:
-            raise LinphoneException('Do not ringing showing {}'.format(self._caller_id))
+            raise LinphoneException(f'Do not ringing showing {self._caller_id}')
 
         return True
 
@@ -169,11 +169,7 @@ class RegisterCommand(BaseCommand):
 
     @property
     def command(self):
-        return 'register sip:{name}@{host} {host} {passwd}'.format(
-            name=self._uname,
-            passwd=self._passwd,
-            host=self._hostname,
-        )
+        return f'register sip:{self._uname}@{self._hostname} {self._hostname} {self._passwd}'
 
 
 class RegisterStatus:
@@ -211,7 +207,7 @@ class ResumeCommand(BaseCommand):
     def command(self):
         if self._call_id is None:
             raise LinphoneException('Invalid call ID')
-        return 'call-resume {}'.format(self._call_id)
+        return f'call-resume {self._call_id}'
 
 
 class TransferCommand(BaseCommand):
@@ -226,7 +222,7 @@ class TransferCommand(BaseCommand):
 
     @property
     def command(self):
-        return 'transfer {}'.format(self._exten)
+        return f'transfer {self._exten}'
 
 
 class UnregisterCommand(BaseCommand):

--- a/linphonelib/server.py
+++ b/linphonelib/server.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -17,7 +17,7 @@ class LinphoneServer:
         self._docker_name = os.path.basename(self._mount_path)
 
     def is_running(self):
-        cmd = ['docker', 'container', 'ls', '-qf', 'name={}'.format(self._docker_name)]
+        cmd = ['docker', 'container', 'ls', '-qf', f'name={self._docker_name}']
         result = subprocess.run(cmd, stdout=subprocess.PIPE)
         return len(result.stdout)
 
@@ -30,7 +30,7 @@ class LinphoneServer:
             '--name',
             self._docker_name,
             '--volume',
-            '{}:/tmp/linphone'.format(self._mount_path),
+            '{self._mount_path}:/tmp/linphone',
             self._DOCKER_IMG,
         ]
         subprocess.run(cmd, stdout=subprocess.DEVNULL)

--- a/linphonelib/session.py
+++ b/linphonelib/session.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -50,6 +50,9 @@ class Session:
 
     def __str__(self):
         return 'Session %(_uname)s@%(_hostname)s' % self.__dict__
+
+    def close(self):
+        self._linphone_wrapper.stop_and_clean()
 
     @_execute
     def answer(self):
@@ -134,9 +137,14 @@ audio_rtp_port={rtp_port}
         self._server = None
         self._configured = False
 
-    def __del__(self):
+    def _log_write(self, message):
+        if self._logfile:
+            self._logfile.write(message)
+
+    def stop_and_clean(self):
         if self._server.is_running():
             self.execute(QuitCommand())
+            self._log_write('Stopping Linphone container...')
             self._wait_until_server_stopped()
 
         if os.path.exists(self._mount_path):


### PR DESCRIPTION
## do not use __del__ to close session

why: It is called when an object is garbage collected which happens at
some point after all references to the object have been deleted.

On error, there is propagating exception which keep a reference and make
the __del__ not called until the end of execution. In this case,
Linphone will try to register until the end of all tests, which will
trigger fail2ban

## use f-string

why: easier to read