### PR TITLE
add carriage return at end of each command

### DIFF
--- a/linphonelib/client.py
+++ b/linphonelib/client.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import collections
@@ -74,6 +74,11 @@ class LinphoneClient:
         self._log_write(f'Send data: {data}')
         if isinstance(data, str):
             data = data.encode('utf-8')
+        # using --pipe option will trigger `setlinebuf(stdout)` in linphone
+        # According setlinebuf documentation, it's like using setvbuf with _IOLBF param
+        # According the setvbuf documentation: The buffer is deleted when a new-line character is
+        # written, when the buffer is full, or when input is requested
+        data += b'\n'
         self._send_data_to_socket(data)
 
     def _send_data_to_socket(self, data):

--- a/linphonelib/session.py
+++ b/linphonelib/session.py
@@ -149,7 +149,6 @@ audio_rtp_port={rtp_port}
             except LinphoneException as e:
                 self._log_write(str(e))
 
-            self._log_write('Stopping Linphone container...')
             self._wait_until_server_stopped()
 
         if os.path.exists(self._mount_path):
@@ -190,12 +189,16 @@ audio_rtp_port={rtp_port}
         return config_file
 
     def _wait_until_server_stopped(self):
-        tries = 10
-        interval = 0.5
+        self._log_write('_wait_until_server_stopped...')
+        tries = 120
+        interval = 1
         for _ in range(tries):
             if not self._server.is_running():
+                self._log_write('Server stopped correctly')
                 return
+            self._log_write('waiting closing server (sleep 1s)')
             time.sleep(interval)
+        self._log_write('forcing stop (kill container)')
         self._server.force_stop()
 
 

--- a/linphonelib/tests/test_client.py
+++ b/linphonelib/tests/test_client.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import socket
@@ -49,14 +49,14 @@ class TestLinphoneClient(unittest.TestCase):
 
         self.client.send_data(raw_data)
 
-        self.socket.sendall.assert_called_once_with(raw_data)
+        self.socket.sendall.assert_called_once_with(raw_data + b'\n')
 
     def test_when_send_decoded_data_then_data_sent_to_socket(self):
         data = 'register xyz'
 
         self.client.send_data(data)
 
-        expected_data = data.encode('utf-8')
+        expected_data = data.encode('utf-8') + b'\n'
         self.socket.sendall.assert_called_once_with(expected_data)
 
     def test_given_not_connected_when_disconnect_then_no_error(self):


### PR DESCRIPTION
why: to potentially fix a behavior when we send command and the command
is not executed. It is to ensure that linphone receive the completed
command.

Sympotome was that command is executed when we close the container
(socket is flushed?) Anyways it doesn't cause issue to add this
safeguard