### PR TITLE
server wait: probe data sending + recving

### DIFF
--- a/linphonelib/client.py
+++ b/linphonelib/client.py
@@ -42,6 +42,8 @@ class LinphoneClient:
         try:
             self._log_write('Probing Linphone server')
             self._connect_socket()
+            self.send_data('call-status\n')
+            self.parse_next_status_message()
             return True
         except LinphoneConnectionError:
             return False

--- a/linphonelib/tests/test_client.py
+++ b/linphonelib/tests/test_client.py
@@ -125,6 +125,8 @@ class TestLinphoneClient(unittest.TestCase):
     @patch('socket.socket')
     def test_is_server_up_true(self, mock_socket_constructor):
         self.client._sock = None
+        mock_socket_constructor.return_value = probing_socket = Mock()
+        probing_socket.recv.return_value = b'\nStatus: Ok'
 
         result = self.client.is_server_up()
 
@@ -141,10 +143,20 @@ class TestLinphoneClient(unittest.TestCase):
         mock_socket_constructor.assert_not_called()
 
     @patch('socket.socket')
-    def test_is_server_up_false_already_connected(self, mock_socket_constructor):
+    def test_is_server_up_false_connection_refused(self, mock_socket_constructor):
         self.client._sock = None
         mock_socket_constructor.return_value = socket = Mock()
         socket.connect.side_effect = OSError('connection refused')
+
+        result = self.client.is_server_up()
+
+        assert result is False
+
+    @patch('socket.socket')
+    def test_is_server_up_false_connection_reset(self, mock_socket_constructor):
+        self.client._sock = None
+        mock_socket_constructor.return_value = socket = Mock()
+        socket.recv.side_effect = OSError('connection reset')
 
         result = self.client.is_server_up()
 


### PR DESCRIPTION
Why:

* On Jenkins, the socket is present and connected, but returns a
  Connection Reset when sending data