### PR TITLE
Pull request for improve-server-wait-3

### DIFF
--- a/linphonelib/client.py
+++ b/linphonelib/client.py
@@ -42,8 +42,6 @@ class LinphoneClient:
         try:
             self._log_write('Probing Linphone server')
             self._connect_socket()
-            self.send_data('call-status\n')
-            self.parse_next_status_message()
             return True
         except LinphoneConnectionError:
             return False

--- a/linphonelib/client.py
+++ b/linphonelib/client.py
@@ -69,6 +69,7 @@ class LinphoneClient:
             raise LinphoneConnectionError(e)
 
     def _disconnect_socket(self):
+        self._sock.shutdown(socket.SHUT_RDWR)
         self._sock.close()
         self._sock = None
         self._buffer = b''

--- a/linphonelib/tests/test_client.py
+++ b/linphonelib/tests/test_client.py
@@ -125,8 +125,7 @@ class TestLinphoneClient(unittest.TestCase):
     @patch('socket.socket')
     def test_is_server_up_true(self, mock_socket_constructor):
         self.client._sock = None
-        mock_socket_constructor.return_value = probing_socket = Mock()
-        probing_socket.recv.return_value = b'\nStatus: Ok'
+        mock_socket_constructor.return_value = Mock()
 
         result = self.client.is_server_up()
 
@@ -147,16 +146,6 @@ class TestLinphoneClient(unittest.TestCase):
         self.client._sock = None
         mock_socket_constructor.return_value = socket = Mock()
         socket.connect.side_effect = OSError('connection refused')
-
-        result = self.client.is_server_up()
-
-        assert result is False
-
-    @patch('socket.socket')
-    def test_is_server_up_false_connection_reset(self, mock_socket_constructor):
-        self.client._sock = None
-        mock_socket_constructor.return_value = socket = Mock()
-        socket.recv.side_effect = OSError('connection reset')
 
         result = self.client.is_server_up()
 


### PR DESCRIPTION
## client: improve socket close


## client: remove useless noisy commands from server probe

Why:

* The main reason for errors was that the runner only had 1 CPU