### PR TITLE
handle no registration in handle_status_ok

### DIFF
--- a/linphonelib/commands.py
+++ b/linphonelib/commands.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from linphonelib.base_command import BaseCommand
@@ -168,15 +168,19 @@ class RegisterCommand(BaseCommand):
 class RegisterStatus:
     REGISTERED = 0
     FAIL = 1
+    NOT_REGISTERED = 2
 
 
 class RegisterStatusCommand(BaseCommand):
     command = 'register-status ALL'
 
     def handle_status_ok(self, message):
-        if message['State'] == 'LinphoneRegistrationOk':
+        state = message.get('State')
+        if state is None:
+            return RegisterStatus.NOT_REGISTERED
+        if state == 'LinphoneRegistrationOk':
             return RegisterStatus.REGISTERED
-        if message['State'] == 'LinphoneRegistrationFailed':
+        if state == 'LinphoneRegistrationFailed':
             return RegisterStatus.FAIL
 
     def handle_status_error(self, message):

--- a/linphonelib/tests/test_commands.py
+++ b/linphonelib/tests/test_commands.py
@@ -1,0 +1,39 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import collections
+import unittest
+from unittest.mock import Mock
+
+from ..commands import RegisterStatus, RegisterStatusCommand
+
+StatusMessage = collections.namedtuple('Message', ['status', 'body'])
+
+
+class TestRegisterStatusCommand(unittest.TestCase):
+    def setUp(self):
+        self.command = RegisterStatusCommand()
+
+    def _make_client(self, status, body):
+        client = Mock()
+        client.parse_next_status_message.return_value = StatusMessage(status, body)
+        return client
+
+    def test_registered(self):
+        client = self._make_client(
+            'Ok', {'Status': 'Ok', 'State': 'LinphoneRegistrationOk'}
+        )
+        result = self.command.execute(client)
+        assert result == RegisterStatus.REGISTERED
+
+    def test_registration_failed(self):
+        client = self._make_client(
+            'Ok', {'Status': 'Ok', 'State': 'LinphoneRegistrationFailed'}
+        )
+        result = self.command.execute(client)
+        assert result == RegisterStatus.FAIL
+
+    def test_no_registration(self):
+        client = self._make_client('Ok', {'Status': 'Ok'})
+        result = self.command.execute(client)
+        assert result == RegisterStatus.NOT_REGISTERED


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change to `RegisterStatusCommand` to handle a previously unhandled response shape, plus unit tests covering the new behavior.
> 
> **Overview**
> `RegisterStatusCommand.handle_status_ok` now treats missing `State` in an `Ok` response as an explicit `NOT_REGISTERED` status (instead of implicitly returning `None`), and adds a new `RegisterStatus.NOT_REGISTERED` enum value.
> 
> Adds unit tests for `RegisterStatusCommand` covering registered, failed, and no-registration responses, and updates the copyright year header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9770d62a289d95bb24ee40e1b2a4a40974fdb879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->