### PR TITLE
commands: return False when there is no current call

### DIFF
--- a/linphonelib/commands.py
+++ b/linphonelib/commands.py
@@ -125,6 +125,8 @@ class IsTalkingToCommand(BaseCommand):
         return True
 
     def handle_status_error(self, message):
+        if message['Reason'] == 'No current call available.':
+            return False
         raise LinphoneException(message['Reason'])
 
 
@@ -144,6 +146,8 @@ class IsRingingShowingCommand(BaseCommand):
         return True
 
     def handle_status_error(self, message):
+        if message['Reason'] == 'No current call available.':
+            return False
         raise LinphoneException(message['Reason'])
 
 

--- a/linphonelib/tests/test_commands.py
+++ b/linphonelib/tests/test_commands.py
@@ -5,7 +5,13 @@ import collections
 import unittest
 from unittest.mock import Mock
 
-from ..commands import RegisterStatus, RegisterStatusCommand
+from ..commands import (
+    IsRingingShowingCommand,
+    IsTalkingToCommand,
+    RegisterStatus,
+    RegisterStatusCommand,
+)
+from ..exceptions import LinphoneException
 
 StatusMessage = collections.namedtuple('Message', ['status', 'body'])
 
@@ -37,3 +43,87 @@ class TestRegisterStatusCommand(unittest.TestCase):
         client = self._make_client('Ok', {'Status': 'Ok'})
         result = self.command.execute(client)
         assert result == RegisterStatus.NOT_REGISTERED
+
+
+class TestIsRingingShowingCommand(unittest.TestCase):
+    def setUp(self):
+        self.command = IsRingingShowingCommand('Good')
+
+    def _make_client(self, status, body):
+        client = Mock()
+        client.parse_next_status_message.return_value = StatusMessage(status, body)
+        return client
+
+    def test_ringing_showing_caller_id(self):
+        client = self._make_client(
+            'Ok',
+            {
+                'Status': 'Ok',
+                'State': 'LinphoneCallIncomingReceived',
+                'From': '"Good" <sip:0015555555555@example.com>',
+            },
+        )
+        result = self.command.execute(client)
+        assert result is True
+
+    def test_no_current_call(self):
+        client = self._make_client(
+            'Error', {'Status': 'Error', 'Reason': 'No current call available.'}
+        )
+        result = self.command.execute(client)
+        assert result is False
+
+    def test_other_error_still_raises(self):
+        client = self._make_client(
+            'Error', {'Status': 'Error', 'Reason': 'Something went wrong.'}
+        )
+        with self.assertRaises(LinphoneException):
+            self.command.execute(client)
+
+    def test_ringing_showing_another_caller_id_raises(self):
+        client = self._make_client(
+            'Ok',
+            {
+                'Status': 'Ok',
+                'State': 'LinphoneCallIncomingReceived',
+                'From': '"Bad" <sip:0015555555551@example.com>',
+            },
+        )
+        with self.assertRaises(LinphoneException):
+            self.command.execute(client)
+
+
+class TestIsTalkingToCommand(unittest.TestCase):
+    def setUp(self):
+        self.command = IsTalkingToCommand('Good')
+
+    def _make_client(self, status, body):
+        client = Mock()
+        client.parse_next_status_message.return_value = StatusMessage(status, body)
+        return client
+
+    def test_talking_to_caller_id(self):
+        client = self._make_client(
+            'Ok',
+            {
+                'Status': 'Ok',
+                'State': 'LinphoneCallStreamsRunning',
+                'From': '"Good" <sip:0015555555555@example.com>',
+            },
+        )
+        result = self.command.execute(client)
+        assert result is True
+
+    def test_no_current_call(self):
+        client = self._make_client(
+            'Error', {'Status': 'Error', 'Reason': 'No current call available.'}
+        )
+        result = self.command.execute(client)
+        assert result is False
+
+    def test_other_error_still_raises(self):
+        client = self._make_client(
+            'Error', {'Status': 'Error', 'Reason': 'Something went wrong.'}
+        )
+        with self.assertRaises(LinphoneException):
+            self.command.execute(client)


### PR DESCRIPTION
## Problem

The daily acceptance build failed on `features/daily/blocklist.feature:18` (*incall to user not blocked by user blocklist*) with:

```
linphonelib.exceptions.LinphoneException: No current call available.
```

The blocklist feature itself worked correctly — the callee's Linphone *did* receive the call with the right caller ID, it just arrived 232 ms after the test polled:

| Time (UTC) | Event |
|---|---|
| 05:54:33.719 | trunk sends `call sip:1001@…` |
| 05:54:34.809 | test polls callee → `No current call available.` → **error** |
| 05:54:35.041 | callee: `LinphoneCallIncomingReceived` From: `"Good" <sip:0015555555555@…>` |

The step is written to absorb exactly this latency — `until.true(phone.is_ringing_showing, callerid, tries=5)` — but `until.true` has no exception handling, so the exception from the first poll propagates out and tries 2-5 never run. The step effectively had a hard 1-second deadline instead of the intended ~5 seconds.

## Fix

`IsRingingShowingCommand.handle_status_error` and `IsTalkingToCommand.handle_status_error` now return `False` for `"No current call available."` instead of raising, so the retry loop sees a falsy poll and tries again.

This makes them consistent with `CallStatusCommand`, which issues the *same* `call-status` command and has always mapped that same reply to a state (`CallStatus.OFF`) rather than an error. That asymmetry is why `is_ringing`/`is_hungup` are reliable while `is_ringing_showing`/`is_talking_to` are flaky.

The raises in `handle_status_ok` are deliberately kept. A wrong caller ID or a call in another state will not resolve by polling again, and `Do not ringing showing Good` after one poll is far more useful than a bare `NoMoreTries(None)` five seconds later.

Any other error reason still raises, so nothing is silently swallowed.

## Testing

- `tox -e py311` — 29 passed, including 10 new cases across both commands: match, no-call-yet, other errors still raising, and caller-ID mismatch still raising.
- `tox -e linters` — clean.
- Replayed the exact failing poll sequence through the real `until.true`: before this change it aborts on poll 1 with the identical `LinphoneException: No current call available.` seen in CI; after, it passes on poll 2. A call that never arrives still fails after all 5 polls.

## Note for wazo-acceptance

`wazo-acceptance/requirements.txt` installs this from `master.zip`, so it needs no change and will pick the fix up on the next run once this merges. The daily build stays flaky until then.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in test-helper commands; errors other than no active call still raise.
> 
> **Overview**
> Fixes flaky acceptance tests where `until.true` retries on `is_ringing_showing` / `is_talking_to` never ran because the first poll raised **`LinphoneException: No current call available.`** instead of returning a falsy value.
> 
> **`IsRingingShowingCommand`** and **`IsTalkingToCommand`** now treat that Linphone error like **`CallStatusCommand`**: **`handle_status_error`** returns **`False`** when the reason is `"No current call available."`**, so retry loops can wait for a late-arriving call. Wrong state, wrong caller ID, and other error reasons still raise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340b72abe248a25cedc2c4e478727def0489faf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->